### PR TITLE
Set default visibility of structure markers to hidden

### DIFF
--- a/src/main/java/com/technicjelle/bluemapstructures/common/Core.java
+++ b/src/main/java/com/technicjelle/bluemapstructures/common/Core.java
@@ -49,7 +49,7 @@ public class Core {
 						.position(new Vector3d(structureChunk.getX() * 16, 64, structureChunk.getY() * 16))
 						.build();
 
-				final MarkerSet markerSet = map.getMarkerSets().computeIfAbsent("structures", id -> MarkerSet.builder().label("Structures").toggleable(true).defaultHidden(false).build());
+				final MarkerSet markerSet = map.getMarkerSets().computeIfAbsent("structures", id -> MarkerSet.builder().label("Structures").toggleable(true).defaultHidden(true).build());
 
 				markerSet.put(structureChunk.toString(), poiMarker);
 			}


### PR DESCRIPTION
Hello - I feel that by default, structure markers should be hidden, I think that BlueMap has good enough integration that a user can enable it with ease.

Ultimately this could be the default until admins are allowed to filter to certain markers as some worlds may have large numbers of external data packs.